### PR TITLE
fix: converting type redefinitions

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -153,7 +153,6 @@ func getValue(fromValue reflect.Value, targetType reflect.Type) (reflect.Value, 
 			}
 		}
 	default:
-		// TODO determine if there are other conversions
 		toValue = fromValue
 	}
 
@@ -182,10 +181,12 @@ func convertValueTypes(value reflect.Value, targetType reflect.Type) (reflect.Va
 	typ := value.Type()
 	switch {
 	// if the Types are the same, just return the value
-	case typ.Kind() == targetType.Kind():
+	case typ == targetType:
 		return value, nil
+	case typ.Kind() == targetType.Kind() && typ.ConvertibleTo(targetType):
+		return value.Convert(targetType), nil
 	case value.IsZero() && isPrimitive(targetType):
-
+		// do nothing, will return nilValue
 	case isPrimitive(typ) && isPrimitive(targetType):
 		// get a string representation of the value
 		str := fmt.Sprintf("%v", value.Interface()) // TODO is there a better way to get a string representation?

--- a/converter_test.go
+++ b/converter_test.go
@@ -39,6 +39,8 @@ func Test_ConvertVar(t *testing.T) {
 }
 
 func Test_Convert(t *testing.T) {
+	type alt string
+
 	type s1 struct {
 		Value string
 	}
@@ -108,6 +110,32 @@ func Test_Convert(t *testing.T) {
 			name: "string equals",
 			from: struct {
 				Value string
+			}{
+				Value: "the value",
+			},
+			to: struct {
+				Value string
+			}{
+				Value: "the value",
+			},
+		},
+		{
+			name: "string to alt type",
+			from: struct {
+				Value string
+			}{
+				Value: "the value",
+			},
+			to: struct {
+				Value alt
+			}{
+				Value: "the value",
+			},
+		},
+		{
+			name: "alt type to string",
+			from: struct {
+				Value alt
 			}{
 				Value: "the value",
 			},


### PR DESCRIPTION
This PR fixes conversion when types are redefined, for example:

```go
type Struct1 struct {
  s string
}

type alt string
type Struct2 struct {
  s alt
}
```