### PR TITLE
chore(deps): restore Go version to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/go-struct-converter
 
-go 1.26.2
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
Restores the go directive in go.mod to 1.23.0 (pre-#16). Bumped in #16 (merge ee58bd60e8d37c4816593ceebc4ef90acd56996e).